### PR TITLE
Removed modified() method and added getModified() instead

### DIFF
--- a/lib/abstract.js
+++ b/lib/abstract.js
@@ -194,6 +194,17 @@ function abstract(namespace, schema, defaults) {
 	}
 
 
+	function getModified() {
+		var modified = _.reduce(object._data, function (result, field, key) {
+			if (field.modified) {
+				result.push(key);
+			}
+			return result;
+		}, []);
+		return _.pick(get(), modified);
+	}
+
+
 	setProperties(object, {
 		set: set,
 		get: get,
@@ -202,9 +213,7 @@ function abstract(namespace, schema, defaults) {
 		initial: function () {
 			return plucker(object._data, 'initial');
 		},
-		modified: function () {
-			return plucker(object._data, 'modified');
-		},
+		getModified: getModified,
 		is: function (ns) {
 			return ns === namespace;
 		},

--- a/test/lib.abstract.js
+++ b/test/lib.abstract.js
@@ -177,18 +177,19 @@ describe('Entity', function () {
 
 	});
 
-	describe('#modified', function () {
+	describe('#getModified', function () {
 
-		it('should not have modified status', function () {
+		it('should not have any modified properties', function () {
 			var entity = gleam.entity('user');
-			expect(entity.modified()).to.deep.equal({id: false, name: false, email: false});
+			expect(entity.getModified()).to.be.empty;
 		});
 
-		it('should set modified flag for set values', function () {
+		it('should add set values to modified fields', function () {
 			var entity = gleam.entity('user');
 			entity.set({id: 1});
-			expect(entity.modified().id).to.be.true;
-			expect(entity.modified().email).to.be.false;
+			expect(entity.getModified()).to.have.keys('id');
+			expect(entity.getModified()).to.be.deep.equal({id: 1});
+			expect(entity.getModified().id).to.equal(1);
 		});
 
 	});

--- a/test/lib.entity.js
+++ b/test/lib.entity.js
@@ -68,9 +68,7 @@ describe('Gleam#entity', function () {
 
 	it('should set defaults without setting modified flag', function () {
 		var entity = gleam.entity('user', userData);
-		expect(entity.modified().id).to.be.false;
-		expect(entity.modified().name).to.be.false;
-		expect(entity.modified().email).to.be.false;
+		expect(entity.getModified()).to.be.empty;
 	});
 
 	it('should fill initial values with defaults', function () {


### PR DESCRIPTION
Shorthand to return hash of modified properties only.
